### PR TITLE
C++ requires that static object destructors are called when the

### DIFF
--- a/STM32F1/platform.txt
+++ b/STM32F1/platform.txt
@@ -22,7 +22,7 @@ compiler.c.elf.flags={build.flags.optimize} -Wl,--gc-sections {build.flags.ldspe
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g {build.flags.optimize} {compiler.warning_flags} -std=gnu++11 -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin} 
+compiler.cpp.flags=-c -g {build.flags.optimize} {compiler.warning_flags} -std=gnu++11 -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -fno-use-cxa-atexit -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin} 
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy


### PR DESCRIPTION
program terminates. Recent versions of GCC use __cxa_atexit to
register exit handlers which call these object destructors.

With the -fno-use-cxa-atexit command line option, GCC uses atexit
instead (same functionality, but only up to 32 exit handlers can
be registered).

Since the Arduino main process can not return, and calls to exit()
simply call an infinite loop - so all of this is completely
irrelevant. No exit handlers are ever called.

By removing the unused __cxa_atexit functionality we save a bit of
space, and enable further cleanups (in later commits).