### PR TITLE
Remove uncallable libc call

### DIFF
--- a/STM32F1/variants/generic_stm32f103c/wirish/start_c.c
+++ b/STM32F1/variants/generic_stm32f103c/wirish/start_c.c
@@ -85,9 +85,6 @@ void __attribute__((noreturn)) start_c(void) {
 
     /* Jump to main. */
     exit_code = main(0, 0, 0);
-    if (exit) {
-        exit(exit_code);
-    }
 
     /* If exit is NULL, make sure we don't return. */
     for (;;)


### PR DESCRIPTION
main() never exits. The subsequent call to exit() links in the libc
exit symbol and all that it calls (including free() and a few others.
Removing this saves around 2k of flash.